### PR TITLE
ファイル保存ボタンに、読み込み機能が登録されていたので保存機能へ修正

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -56,7 +56,7 @@ function onLoad() {
   });
   // 「保存する」ボタンの制御
   document.querySelector('#btnSave').addEventListener('click', () => {
-    openLoadFile();
+    saveFile();
   });
 };
 


### PR DESCRIPTION
保存ボタンのリスナーで、登録されているfunctionが読み込みようの、 `openLoadFile()` ですが、
本来実行したかったのは、保存用の `saveFile()` ではないでしょうか。
修正のpull requestをお送ります。